### PR TITLE
Small error fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "playwright-stealth"
 dynamic = ["version"]
 description = "playwright stealth"
 readme = "README.md"
-license = ""
+license = { text = "MIT" }
 requires-python = ">=3.8"
 authors = [
     { name = "AtuboDad", email = "lcjasas@sina.com" },

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    package_data={"playwright_stealth": ["js/*.js"]},
+    package_data={"playwright_stealth": ["js/*.js", "js/mitigations/*.js"]},
     python_requires=">=3.8",
     install_requires=[
         "playwright",

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    package_data={"playwright_stealth": ["js/*.js", "js/mitigations/*.js"]},
+    package_data={"playwright_stealth": ["js/*.js", "js/**/*.js"]},
     python_requires=">=3.8",
     install_requires=[
         "playwright",


### PR DESCRIPTION
Hello, thank you for deciding to update and revitalise the `playwright-stealth` that was abandoned for almost a year. You've done a really cool job 🔥

But during the adding of the package via `poetry add git+https://github.com/mattwmaster58/playwright_stealth`, it failed because of the invalid licence param in `the pyproject.toml`. I added a MIT licence there.
<img width="1321" alt="image" src="https://github.com/user-attachments/assets/60e602b6-ff0a-4c67-928c-1da5d08ea366">

Also after the first run of the library I encountered an error - not all js-files were included to the `package_data`, I also updated it:
<img width="1383" alt="image" src="https://github.com/user-attachments/assets/a37f723d-4851-4943-9266-d8d5ac19507c">
 
 By the way, how do you think, @Mattwmaster58, maybe change `js/mitigations/*.js` to `js/**/*.js`?