### PR TITLE
chg: Makes Error.prototype.name non-configurable

### DIFF
--- a/playwright_stealth/js/utils.js
+++ b/playwright_stealth/js/utils.js
@@ -3,6 +3,17 @@
  */
 const utils = {};
 
+/** Notes
+ * It is possible to trigger a call to Error.prototype.name with
+ * const e = new Error()
+ * console.debug(e)
+ */
+
+Object.defineProperty(Error.prototype, 'name', {
+          configurable: false,
+          enumerable: false,
+          });
+
 /**
  * Wraps a JS Proxy Handler and strips it's presence from error stacks, in case the traps throw.
  * The presence of a JS Proxy can be revealed as it shows up in error stack traces.


### PR DESCRIPTION
Related: https://github.com/Mattwmaster58/playwright_stealth/issues/19